### PR TITLE
Fix/v0.6.2

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -174,4 +174,4 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 });
 </script>
-<!-- 🛠️ Fixed: Jinja2 템플릿 렌더링 오류를 유발하는 중복된 'title' 블록을 제거합니다. -->
+{% endblock %}


### PR DESCRIPTION
Fixed: yfinance API 호출 오류 수정:
- 원인: get_stock_prices_bulk 메서드에서 yf.Tickers() 내부의 개별 history() 호출 시, 지원되지 않는 progress=False 인수를 전달하여 TypeError가 발생했습니다.
해결: stock_api.py에서 해당 인수를 제거하여 yfinance 라이브러리의 올바른 사용법에 맞게 수정했습니다. 이로써 벌크 API 호출 기능이 정상적으로 작동합니다.

Fixed: Jinja2 템플릿 렌더링 오류 수정:
- 원인: templates/dashboard.html 파일에서 {% block scripts %}가 파일 끝에서 {% endblock %}으로 닫히지 않아 TemplateSyntaxError가 발생했습니다.
해결: 파일의 마지막에 누락된 {% endblock %} 태그를 추가하여 템플릿의 블록 구조를 바로잡았습니다. 이 수정으로 대시보드 페이지가 정상적으로 로드됩니다.